### PR TITLE
Convert from Bash to PHP

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -11,7 +11,7 @@ define fooacl::conf (
   include '::fooacl'
 
   concat::fragment { $title:
-    target  => '/usr/local/sbin/fooacl',
+    target  => '/usr/local/sbin/fooacl.php',
     order   => $order,
     content => template("${module_name}/20.erb"),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,24 +11,24 @@ class fooacl ( $noop = false ) {
 
   $notify = $noop ? {
     true  => undef,
-    false => Exec['/usr/local/sbin/fooacl'],
+    false => Exec['/usr/local/sbin/fooacl.php'],
   }
 
   # Main script, to apply ACLs when the configuration changes
-  exec { '/usr/local/sbin/fooacl':
+  exec { '/usr/local/sbin/fooacl.php':
     refreshonly => true,
   }
-  concat { '/usr/local/sbin/fooacl':
+  concat { '/usr/local/sbin/fooacl.php':
     mode   => '0755',
     notify => $notify,
   }
   concat::fragment { 'fooacl-header':
-    target  => '/usr/local/sbin/fooacl',
+    target  => '/usr/local/sbin/fooacl.php',
     order   => 10,
     content => template("${module_name}/10.erb"),
   }
   concat::fragment { 'fooacl-footer':
-    target  => '/usr/local/sbin/fooacl',
+    target  => '/usr/local/sbin/fooacl.php',
     order   => 30,
     content => template("${module_name}/30.erb"),
   }

--- a/templates/10.erb
+++ b/templates/10.erb
@@ -1,9 +1,7 @@
-#!/bin/bash
-
+#!/usr/bin/php
+<?php
 # Initial global ACLs for each path to manage
-ACLOPTS_GLOBAL="-R -b"
-
-# Create array to store ACLs, with keys for each path to manage
-declare -A ACLOPTS
+$aclopts_global = "-R -b";
 
 # Construct the final ACLs from snippets
+$aclopts = array(

--- a/templates/20.erb
+++ b/templates/20.erb
@@ -1,7 +1,7 @@
 <% @target.each do |f| -%>
 <% if f == 'default' -%>
-ACLOPTS_GLOBAL+="<% @permissions.each do |p| %> -m <%= p %> -m d:<%= p %><% end %>"
+ACLOPTS_GLOBAL+="<%@permissions.each do |p| %> -m <%= p %> --set d:<%= p %><% end %>"
 <% else -%>
-ACLOPTS[<%= f %>]+="<% @permissions.each do |p| %> -m <%= p %> -m d:<%= p %><% end %>"
+     '<%= f %>' => '<% @permissions.each do |p| %> -m <%= p %> --set d:<%= p %><% end %>',
 <% end -%>
 <% end -%>

--- a/templates/30.erb
+++ b/templates/30.erb
@@ -1,6 +1,14 @@
+);
 
-# Apply the ACLs. Any existing ACLs will be replaced
-for DIR in ${!ACLOPTS[@]}; do
-  setfacl ${ACLOPTS_GLOBAL} ${ACLOPTS[${DIR}]} ${DIR}
-done
+
+// Sort array
+ksort($aclopts);
+
+foreach($aclopts as $dir => $acl_arg) {
+   $cmd = "setfacl $aclopts_global $acl_arg $dir\n";
+   echo exec('echo ' .  $cmd) . "\n";
+   exec($cmd) . "\n";
+}
+
+?>
 


### PR DESCRIPTION
In conf.pp and init.pp /usr/local/sbin/fooacl is now /usr/local/sbin/fooacl.php (to reflect it's php code and not bash code).  

The templates now generate PHP code instead of Bash.  The PHP code sorts the array alphabetically so that sub-directory ACLs don't get overwritten by parent dirs.
