### PR TITLE
Changed the depdendency from a dash to a forward slash.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-03-14 - 0.1.2
+* Fix misconfigured dependency on puppetlabs/concat causing librarian-puppet
+  and probably others to barf.
+
 2014-02-11 - 0.1.1
 * Sort so that sub-directory ACLs get applied after parent directory ACLs.
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,9 +1,9 @@
 name 'thias-fooacl'
-version '0.1.1'
+version '0.1.2'
 source 'git://github.com/thias/puppet-fooacl'
 author 'Matthias Saou'
 license 'Apache 2.0'
 summary 'POSIX filesystem ACLs module.'
 description "Manage POSIX filesystem ACLs in a flexible way with puppet."
 project_page 'https://github.com/thias/puppet-fooacl'
-dependency 'puppetlabs-concat'
+dependency 'puppetlabs/concat'


### PR DESCRIPTION
With the dash in the Module require line, librarian-puppet does this:

My Puppet file contained:

```
mod 'thias/fooacl'
```

(among other, but working, modules).

Here's what happened:

```
[root@centos64 puppet]# !librar
librarian-puppet  install
/usr/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.14/lib/librarian/puppet/source/forge.rb:186:in `api_call': Error requesting http://forge.puppetlabs.com/api/v1/releases.json?module=puppetlabs-concat: 400 Bad Request (OpenURI::HTTPError)
    from /usr/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.14/lib/librarian/puppet/source/forge.rb:155:in `api_data'
    from /usr/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.14/lib/librarian/puppet/source/forge.rb:29:in `versions'
```

That's because the module should (in this case) be specified with a /.

I forked this module to make this quick fix as it was blocking further work.

```
[root@centos64 puppet]# librarian-puppet  install
[root@centos64 puppet]# vim Puppetfile
```

librarian-puppet is quite indicating success.
