### PR TITLE
rename noop to fooacl_noop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ fooacl::conf { 'backend':
 
 ## Debugging
 
-You can set the module `noop` globally using hiera :
+You can set the module `fooacl_noop` globally using hiera :
 ```yaml
 ---
-fooacl::noop: true
+fooacl::fooacl_noop: true
 ```
 
 After which the `/usr/local/sbin/fooacl` script will get updated but won't

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,11 +5,11 @@
 # Sample Usage :
 #  include '::fooacl'
 #
-class fooacl ( $noop = false ) {
+class fooacl ( $fooacl_noop = false ) {
 
   include '::concat::setup'
 
-  $notify = $noop ? {
+  $notify = $fooacl_noop ? {
     true  => undef,
     false => Exec['/usr/local/sbin/fooacl'],
   }


### PR DESCRIPTION
fixes #4

This solves the warning thrown by puppet when running:
noop is a metaparam; this value will inherit to all contained resources
in the fooacl definition

For better or worst, I'm renamed it to fooacl_noop
