### PR TITLE
Install required packages for acl functionality

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,9 +5,18 @@
 # Sample Usage :
 #  include '::fooacl'
 #
-class fooacl ( $fooacl_noop = false ) {
+class fooacl (
+  $fooacl_noop      = false,
+  $acl_package_name = $::fooacl::params::acl_package_name,
+) inherits ::fooacl::params {
 
   include '::concat::setup'
+
+  if $acl_package_name {
+    package { $acl_package_name:
+      ensure => 'present',
+    }
+  }
 
   $notify = $fooacl_noop ? {
     true  => undef,
@@ -17,6 +26,7 @@ class fooacl ( $fooacl_noop = false ) {
   # Main script, to apply ACLs when the configuration changes
   exec { '/usr/local/sbin/fooacl':
     refreshonly => true,
+    require     => Package[$acl_package_name],
   }
   concat { '/usr/local/sbin/fooacl':
     mode   => '0755',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,14 @@
+# Class: fooacl::params
+#
+# Per-platform parameters for fooacl class
+#
+class fooacl::params {
+  case $::osfamily {
+    'gentoo': {
+      $acl_package_name = 'sys-apps/acl'
+    }
+    default: {
+      $acl_package_name = 'acl'
+    }
+  }
+}


### PR DESCRIPTION
Some distros need a separate package for ACL functionality. I don't use RHEL or CentOS, so I'm not sure if any other packages are needed. I don't believe they need any, so the parameter will be set to `undef` and should have no affect. 
