### PR TITLE
Add a modifyonly parameter to stop the default acl being applied all the time

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -6,6 +6,7 @@ define fooacl::conf (
   $target      = $name,
   $order       = 20,
   $permissions,
+  $modifyonly  = false,
 ) {
 
   include '::fooacl'

--- a/templates/20.erb
+++ b/templates/20.erb
@@ -11,6 +11,6 @@ end
 <% if f == 'default' -%>
 ACLOPTS_GLOBAL+="<% @permissions.flatten.each do |p| %> -m <%= p %> -m d:<%= p %><% end %>"
 <% else -%>
-ACLOPTS[<%= f %>]+="<% @permissions.flatten.each do |p| %> -m <%= p %> -m d:<%= p %><% end %>"
+ACLOPTS[<%= f %>]+="<% @permissions.flatten.each do |p| %> -m <%= p %> <% if !@modifyonly %> -m d:<%= p %><% end %><% end %>"
 <% end -%>
 <% end -%>


### PR DESCRIPTION
The second -m d:<% p %> is not really needed since we can just set

parameter => u:userX:rwx,d:u:userX:rwx