### PR TITLE
perform fooacl::conf::target string or array validation within the manifest

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -8,6 +8,10 @@ define fooacl::conf (
   $order       = 20,
 ) {
 
+  if ! (is_string($target) or is_array($target)) {
+    fail('$target must be a string or an array')
+  }
+
   include '::fooacl'
 
   concat::fragment { $title:

--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,10 @@
     {
     "name": "puppetlabs/concat",
     "version_requirement": ">= 1.0.0"
+    },
+    {
+    "name": "puppetlabs/stdlib",
+    "version_requirement": ">= 4.2.0"
     }
   ]
 }

--- a/templates/20.erb
+++ b/templates/20.erb
@@ -3,8 +3,6 @@ if @target.is_a?(String)
   target = @target.lines
 elsif @target.is_a?(Array)
   target = @target
-else
-  fail("The target must be a string or an array")
 end
 -%>
 <% target.each do |f| -%>


### PR DESCRIPTION
I think it's better to have variables validation done within the manifest itself. I wouldn't have mind so much but this got caught in a puppet syntax:manifests test job that we had.

Let me know what you think.

Thanks!