### PR TITLE
Make recursivity optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Manage POSIX filesystem ACLs with Puppet.
 
 Most (all?) other ACL modules implement a type which can be declared only once
 per file, which isn't flexible. This module takes the unusual approach of
-creating a single large concatenated script to manage all ACLs recursively in
+creating a single large concatenated script to manage all ACLs in
 a single run. Ugly, yet very efficient and flexible since ACLs aren't tied to
 the `file` type in any way.
 
@@ -103,6 +103,17 @@ fooacl::conf { 'backend':
   permissions => [
     'user:userZ:rwX',
   ],
+}
+# Some configuration file
+fooacl::conf { configuration':
+  target => [
+    '/etc/nginx/sites-available/backend.example.com.conf',
+    '/etc/nginx/sites-available/backend.example.org.conf',
+  ],
+  permissions => [
+    'user:userZ:rwX',
+  ],
+  recursive => false,
 }
 ```
 

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -5,6 +5,7 @@
 define fooacl::conf (
   $permissions,
   $target      = $name,
+  $recurse     = true,
   $order       = 20,
 ) {
 

--- a/templates/10.erb
+++ b/templates/10.erb
@@ -4,7 +4,7 @@
 set -e
 
 # Initial global ACLs for each path to manage
-ACLOPTS_GLOBAL="-R -b"
+ACLOPTS_GLOBAL="-b"
 
 # Create array to store ACLs, with keys for each path to manage
 declare -A ACLOPTS

--- a/templates/20.erb
+++ b/templates/20.erb
@@ -11,6 +11,6 @@ end
 <% if f == 'default' -%>
 ACLOPTS_GLOBAL+="<% @permissions.flatten.each do |p| %> -m <%= p %> -m d:<%= p %><% end %>"
 <% else -%>
-ACLOPTS[<%= f %>]+="<% @permissions.flatten.each do |p| %> -m <%= p %> -m d:<%= p %><% end %>"
+ACLOPTS[<%= f %>]+="<% if @recurse %>-R<% end %><% @permissions.flatten.each do |p| %> -m <%= p %><%if @recurse %>-m d:<%= p %><% end %><% end %>"
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Recursion can be disabled on a per-target basis. Just specifiy `recurse
=> false`. An example has been added.

See #20. This is not an ideal solution has we assume that `recurse => no` means no directory. Good enough for me.