### PR TITLE
Made acl package ensure state a class param

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,13 +6,14 @@
 #  include '::fooacl'
 #
 class fooacl (
-  $fooacl_noop      = false,
-  $acl_package_name = $::fooacl::params::acl_package_name,
+  $fooacl_noop        = false,
+  $acl_package_ensure = 'present',
+  $acl_package_name   = $::fooacl::params::acl_package_name,
 ) inherits ::fooacl::params {
 
   if $acl_package_name {
     package { $acl_package_name:
-      ensure => 'present',
+      ensure => $acl_package_ensure,
     }
   }
 


### PR DESCRIPTION
The ensure value of the acl package was hardcoded, it can now be overwritten in Puppet DSL or via Hiera.