### PR TITLE
Support spaces in filenames

### DIFF
--- a/templates/30.erb
+++ b/templates/30.erb
@@ -1,9 +1,7 @@
 
 # Apply the ACLs. Any existing ACLs will be replaced
 DIRSORTED="$(for DIR in "${!ACLOPTS[@]}"; do echo $DIR; done | sort)"
-IFS=$'\n'
-for DIR in ${DIRSORTED}; do
+while read -r DIR ; do
   setfacl ${ACLOPTS_GLOBAL} ${ACLOPTS[${DIR}]} ${DIR}
-done
-unset IFS
+done <<< "${DIRSORTED}"
 

--- a/templates/30.erb
+++ b/templates/30.erb
@@ -2,6 +2,6 @@
 # Apply the ACLs. Any existing ACLs will be replaced
 DIRSORTED="$(for DIR in "${!ACLOPTS[@]}"; do echo $DIR; done | sort)"
 while read -r DIR ; do
-  setfacl ${ACLOPTS_GLOBAL} ${ACLOPTS[${DIR}]} ${DIR}
+  setfacl ${ACLOPTS_GLOBAL} ${ACLOPTS[${DIR}]} "${DIR}"
 done <<< "${DIRSORTED}"
 

--- a/templates/30.erb
+++ b/templates/30.erb
@@ -1,7 +1,9 @@
 
 # Apply the ACLs. Any existing ACLs will be replaced
 DIRSORTED="$(for DIR in "${!ACLOPTS[@]}"; do echo $DIR; done | sort)"
+IFS=$'\n'
 for DIR in ${DIRSORTED}; do
   setfacl ${ACLOPTS_GLOBAL} ${ACLOPTS[${DIR}]} ${DIR}
 done
+unset IFS
 


### PR DESCRIPTION
The current module doesn't support spaces in filenames as ACL targets, so this update uses a while loop reading a line at a time from the variable to operate upon, and correctly quotes the directory variable in the loop.